### PR TITLE
1.3.1.4: "Megaphone" button visibility and guides page minor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Simply dark allows you to customize some parts of the Steam client component. Fo
 1. **URL visibility**: Allows you to hide the URL bar when browsing inside the Steam client.
 1. **"What's New" visibility**: Allows you to hide recent updates and news from the games you own inside the library page.
 1. **Friends Outline**: Allows you show the friends status in friends tab via outline in the avatar.
+1. **Steam News Visibility**: Allows you hide the "megaphone" (steam news) icon on top right.
 
 ## Contributing
 The theme itself does not require anything being built, but to edit the theme you have to launch Steam with -dev mode.

--- a/Steam.css
+++ b/Steam.css
@@ -666,9 +666,9 @@ div.NarrowRightPanel .appdetailsprimarylinkssection_LinksSection_3-V8v {
     border-top: none !important;
 }
 
-._1TdaAqMFadi0UTqilrkelR ._1KrJ3sFAqPBN9mfpaNTU5F, ._2foCkpRXhqq0UGVE50BWqj ._1KrJ3sFAqPBN9mfpaNTU5F {
+/* ._1TdaAqMFadi0UTqilrkelR ._1KrJ3sFAqPBN9mfpaNTU5F, ._2foCkpRXhqq0UGVE50BWqj ._1KrJ3sFAqPBN9mfpaNTU5F {
     margin-right: -7px;
-}
+} */
 
 ._2foCkpRXhqq0UGVE50BWqj ._1KrJ3sFAqPBN9mfpaNTU5F, .ip-YZhijAMZcuRoXBGiye ._1KrJ3sFAqPBN9mfpaNTU5F, ._1TdaAqMFadi0UTqilrkelR ._1KrJ3sFAqPBN9mfpaNTU5F, ._5wILZhsLODVwGfcJ0hKmJ, .RtSv39ZoBOySnb8XQ5hJf._9YK5IY219Pm_F53DAxyYp ._34bQcTHo5QKzuujoEyU1tm, .RtSv39ZoBOySnb8XQ5hJf._3qhGkQ5qLVNQQ-J2-uPoHt ._34bQcTHo5QKzuujoEyU1tm {
     color: var(--darkerwhite) !important;

--- a/config/NewsButtonVisibility.css
+++ b/config/NewsButtonVisibility.css
@@ -1,0 +1,3 @@
+._2Szzh5sKyGgnLUR870zbDE._5wILZhsLODVwGfcJ0hKmJ {
+    display: none !important;
+}

--- a/skin.json
+++ b/skin.json
@@ -69,6 +69,18 @@
                     }
                 }
             }
+        },
+        "Steam News Visibility": {
+            "description": "Show 'Steam News' button (megaphone) on top right",
+            "default": "Show",
+            "values": {
+                "Show": {},
+                "Hide": {
+                    "TargetCss": {
+                        "affects": ["^Steam$"], "src": "config/NewsButtonVisibility.css"
+                    }
+                }
+            }
         }
     },
     "Configuration": [

--- a/webkit/webkit.css
+++ b/webkit/webkit.css
@@ -868,7 +868,6 @@ span.bb_spoiler{border-radius:var(--border0)!important}
 .avatar_workshop_overlay{background:0 0!important}
 .current_player_workshop_link{padding-left:60px!important}
 .joinGroup{border-radius:var(--border0)!important;width:240px!important;height:80px!important;background:var(--darkgrey)!important}
-.joinGroupTitle{margin-left:50px!important}
 #ig_bottom .sidebar .detailPanel,#ig_bottom .sidebar .panel{background:var(--grey)!important;border-radius:var(--border0)!important}
 .subscribeRSS{padding-top:15px!important;padding-bottom:5px!important}
 .right_column .panel{background:var(--grey)!important;border-radius:var(--border0)!important}
@@ -1214,3 +1213,10 @@ a:hover, body.v6 .store_nav .popup_menu_subheader, body.v6 .deep_dive_tag, .home
     background: var(--color-dark) !important;
     color: var(--darkerwhite);
 }
+
+/* Workshop Page */
+.current_player_workshop_title a {
+    padding-left: 60px !important
+}
+
+.joinGroupTitle{margin-left:15px!important}


### PR DESCRIPTION
- Users can now hide the Steam News button (the megaphone) from the top right.
- Fixed minor elements alignment issues on "Guides" page.